### PR TITLE
Fixed mparser-pcre depencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ null  :=
 space := $(null) #
 comma := ,
 
-PKGS := unix,str,hashcons,hashset,mparser.pcre,ocamlgraph,dynlink
+PKGS := unix,str,hashcons,hashset,mparser-pcre,ocamlgraph,dynlink
 TAGS := debug,explain,annot,use_libsoundness
 OCAMLDOC := ocamldoc -hide-warnings
 INCLUDES := $(subst $(space),$(comma),$(strip $(wildcard src/*)))

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name lib)
  (public_name cyclist.lib)
- (libraries mparser.pcre unix hashset hashcons)
+ (libraries mparser-pcre unix hashset hashcons)
  (modules (:standard \ lru)))

--- a/src/seplog/dune
+++ b/src/seplog/dune
@@ -1,7 +1,7 @@
 (library 
  (name seplog)
  (public_name cyclist.seplog)
- (libraries lib generic mparser.pcre)
+ (libraries lib generic mparser-pcre)
  (modules
    (:standard 
       \ slinit

--- a/src/while/dune
+++ b/src/while/dune
@@ -1,7 +1,7 @@
 (library
  (name while)
  (public_name cyclist.while)
- (libraries lib generic seplog mparser.pcre)
+ (libraries lib generic seplog mparser-pcre)
  (modules
    (:standard \ 
         abduce


### PR DESCRIPTION
The dune build failed due to new mparser structure.
The mparser project moved to the dune build system and moved
the pcre into a seperate package.
See commit 56d3c9 in mparser.